### PR TITLE
feat: 實作搜尋待辦事項功能 (closes #5)

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -8,7 +8,11 @@ TODOS_FILE = "todos.json"
 
 def load_todos():
     """讀取 todos.json，回傳資料 dict。若檔案不存在則回傳初始結構。"""
-    pass
+    try:
+        with open(TODOS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"next_id": 1, "todos": []}
 
 
 def save_todos(data):
@@ -40,7 +44,14 @@ def delete_todo(todo_id):
 
 def search_todos(keyword):
     """Issue #5：搜尋包含關鍵字的待辦事項。"""
-    pass
+    data = load_todos()
+    results = [t for t in data["todos"] if keyword in t["text"]]
+    if not results:
+        print("找不到符合的待辦事項")
+        return
+    for t in results:
+        status = "✅" if t["done"] else "⬜"
+        print(f"[{t['id']}] {status} {t['text']}")
 
 
 def show_stats():

--- a/todo.py
+++ b/todo.py
@@ -8,11 +8,7 @@ TODOS_FILE = "todos.json"
 
 def load_todos():
     """讀取 todos.json，回傳資料 dict。若檔案不存在則回傳初始結構。"""
-    try:
-        with open(TODOS_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError:
-        return {"next_id": 1, "todos": []}
+    pass
 
 
 def save_todos(data):


### PR DESCRIPTION
## Summary
- 實作 `search_todos(keyword)` 函式，支援以關鍵字搜尋待辦事項

## 變更內容

### `search_todos(keyword)`
- 呼叫 `load_todos()` 讀取所有待辦事項
- 篩選 `text` 欄位包含關鍵字的項目
- 有符合結果：逐筆顯示 `[id] ✅/⬜ 內容`
- 無符合結果：顯示「找不到符合的待辦事項」

> **注意：** 此 PR 依賴 `load_todos()` 的實作，需待該函式完成後才能正常運作。

## 測試方式

```bash
# 先確認 load_todos() 已實作，再建立測試資料
echo '{"next_id":6,"todos":[{"id":1,"text":"買牛奶","done":true},{"id":2,"text":"寫週報","done":false},{"id":5,"text":"買牛排","done":false}]}' > todos.json

# 搜尋有結果的情況
python todo.py search "牛"
# 預期輸出：
# [1] ✅ 買牛奶
# [5] ⬜ 買牛排

# 搜尋無結果的情況
python todo.py search "不存在"
# 預期輸出：
# 找不到符合的待辦事項

# 清除測試資料
rm todos.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)